### PR TITLE
Enable auto_pagination for repositories with more than 100 PRs

### DIFF
--- a/lib/GitHub/MergeVelocity/Repository.pm
+++ b/lib/GitHub/MergeVelocity/Repository.pm
@@ -82,6 +82,8 @@ sub _get_pull_requests {
         params => { per_page => 100, state => 'all' },
     );
 
+    $result->auto_pagination(1);
+
     my @pulls;
 
     while ( my $row = $result->next ) {


### PR DESCRIPTION
Hello,

It is a cool module :+1: I love it :grinning:

The code needs this change to go beyond 100 PRs.

Without `auto_pagination(1)` (vanilla GitHub::MergeVelocity):
```bash
$ perl -Ilib bin/github-mergevelocity --url Perl/perl5
.------+-------+----------+-----+----------+------------+----------+------------+----------+-------------.
| user | repo  | velocity | PRs | merged   | merge days | closed   | close days | open     | open days   |
+------+-------+----------+-----+----------+------------+----------+------------+----------+-------------+
| Perl | perl5 | 127      | 100 | 53% (53) | 4/PR (221) | 13% (13) | 4/PR (47)  | 34% (34) | 16/PR (549) |
'------+-------+----------+-----+----------+------------+----------+------------+----------+-------------'
```

With `auto_pagination(1)`:
```bash
$ perl -Ilib bin/github-mergevelocity --url Perl/perl5
.------+-------+----------+------+-----------+---------------+-----------+---------------+---------+----------------.
| user | repo  | velocity | PRs  | merged    | merge days    | closed    | close days    | open    | open days      |
+------+-------+----------+------+-----------+---------------+-----------+---------------+---------+----------------+
| Perl | perl5 | 118      | 1444 | 65% (936) | 15/PR (13902) | 30% (428) | 47/PR (20167) | 6% (80) | 166/PR (13276) |
'------+-------+----------+------+-----------+---------------+-----------+---------------+---------+----------------'
```
